### PR TITLE
fixed deprecated express-session init options

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use(session({ secret: 'shhsecret' }));
+app.use(session({ secret: 'shhsecret', resave: true, saveUninitialized: true }));
 app.use(passport.initialize());
 app.use(passport.session());
 app.use(flash());


### PR DESCRIPTION
according to https://github.com/expressjs/session/issues/56
two new params have to be added
